### PR TITLE
Various Fixes

### DIFF
--- a/Admin-Manticore.english.php
+++ b/Admin-Manticore.english.php
@@ -43,11 +43,14 @@ $txt['manticore_searchd_server_subtext'] = 'Server the Manticore search deamon r
 $txt['manticore_searchd_bind'] = 'Bind daemon to interface';
 $txt['manticore_searchd_bind_subtext'] = 'Binds the daemon to the Manticore server address.';
 
-$txt['manticoreql_searchd_port'] = 'Manticore port';
-$txt['manticoreql_searchd_port_subtext'] = 'Port on which the search deamon will listen.';
+$txt['manticore_searchd_port'] = 'Manticore port';
+$txt['manticore_searchd_port_subtext'] = 'Port on which the search deamon will listen.';
 
 $txt['manticore_max_results'] = 'Maximum # matches';
 $txt['manticore_max_results_subtext'] = 'Maximum amount of matches the search deamon will return.';
+
+$txt['manticore_version'] = 'Manticore Version';
+$txt['manticore_version_subtext'] = 'If the binary is accessible, it will attempt to auto detect, otherwise fall back to this.';
 
 $txt['manticore_config_hints_save'] = 'Please save your configuration first.';
 $txt['manticore_config_hints_desc'] = 'Create directories for storing the indexes: %1$s';

--- a/Admin-Sphinx.english.php
+++ b/Admin-Sphinx.english.php
@@ -46,6 +46,9 @@ $txt['sphinxql_searchd_port_subtext'] = 'Port on which the search deamon will li
 $txt['sphinx_max_results'] = 'Maximum # matches';
 $txt['sphinx_max_results_subtext'] = 'Maximum amount of matches the search deamon will return.';
 
+$txt['sphinx_version'] = 'Sphinx Version';
+$txt['sphinx_version_subtext'] = 'If the binary is accessible, it will attempt to auto detect, otherwise fall back to this.';
+
 $txt['search_index'] = 'SMF Search API';
 $txt['sphinx_smf_search_standard'] = 'Standard (Default)';
 $txt['sphinx_smf_search_fulltext'] = 'Fulltext';

--- a/License.txt
+++ b/License.txt
@@ -1,4 +1,4 @@
-Copyright © 2022 Simple Machines. All rights reserved.
+Copyright © 2023 Simple Machines. All rights reserved.
 
  Developed by: Simple Machines Forum Project
  Simple Machines

--- a/SMF 2.0/SearchAPI-Sphinxql.php
+++ b/SMF 2.0/SearchAPI-Sphinxql.php
@@ -5,12 +5,12 @@
  *
  * @package SMF
  * @author Simple Machines https://www.simplemachines.org
- * @copyright 2019 Simple Machines and individual contributors
+ * @copyright 2023 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
  * The Following fixes a bug in SMF to show this in the settings section.
  * SearchAPI-Sphinxql.php
- * @version 2.0.15
+ * @version 2.0.19
  */
 
 if (!defined('SMF'))
@@ -365,7 +365,7 @@ class sphinxql_search
 			$cleanWords = $this->_cleanString($token[2]);
 
 			// Explode the cleanWords again incase the cleaning put more spaces into it
-			$addWords = $phrase ? array('"' . $cleanWords . '"') : preg_split('~ ~u', $cleanWords, NULL, PREG_SPLIT_NO_EMPTY);
+			$addWords = $phrase ? array('"' . $cleanWords . '"') : preg_split('~ ~u', $cleanWords, -1, PREG_SPLIT_NO_EMPTY);
 
 			if ($token[1] == '-')
 				$keywords['exclude'] = array_merge($keywords['exclude'], $addWords);

--- a/SMF 2.1/SearchAPI-Manticore.php
+++ b/SMF 2.1/SearchAPI-Manticore.php
@@ -328,6 +328,12 @@ class manticore_search extends search_api
 		foreach ($searchWords as $orIndex => $words)
 			$searchArray = array_merge($searchArray, $searchWords[$orIndex]['subject_words']);
 
+		// Work around SMF bug causing multiple pages to not work right.
+		if (!isset($_SESSION['search_cache']['num_results']))
+			$_SESSION['search_cache'] = [
+				'num_results' => $cached_results['total']
+			];
+
 		return $cached_results['total'];
 	}
 

--- a/SMF 2.1/SearchAPI-Manticore.php
+++ b/SMF 2.1/SearchAPI-Manticore.php
@@ -5,12 +5,12 @@
  *
  * @package SMF
  * @author Simple Machines https://www.simplemachines.org
- * @copyright 2021 Simple Machines and individual contributors
+ * @copyright 2023 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
  * The Following fixes a bug in SMF to show this in the settings section.
  * SearchAPI-Manticore.php
- * @version 2.1.0
+ * @version 2.1.3
  */
 
 if (!defined('SMF'))
@@ -362,7 +362,7 @@ class manticore_search extends search_api
 			$cleanWords = $this->_cleanString($token[2]);
 
 			// Explode the cleanWords again incase the cleaning put more spaces into it
-			$addWords = $phrase ? array('"' . $cleanWords . '"') : preg_split('~ ~u', $cleanWords, NULL, PREG_SPLIT_NO_EMPTY);
+			$addWords = $phrase ? array('"' . $cleanWords . '"') : preg_split('~ ~u', $cleanWords, -1, PREG_SPLIT_NO_EMPTY);
 
 			if ($token[1] == '-')
 				$keywords['exclude'] = array_merge($keywords['exclude'], $addWords);

--- a/SMF 2.1/SearchAPI-Manticore.php
+++ b/SMF 2.1/SearchAPI-Manticore.php
@@ -814,8 +814,19 @@ class manticore_search extends search_api
 		if (empty($modSettings['manticore_bin_path']))
 			$modSettings['manticore_bin_path'] = '/usr/bin';
 
-		if (!file_exists(realpath($modSettings['manticore_bin_path'] . '/indexer')))
+		// Try to safely check for the indexer file, but do this in a way we can catch the error so PHP doesn't output it.
+		try {
+			set_error_handler(static function ($severity, $message, $file, $line) {
+				throw new \ErrorException($message, 0, $severity, $file, $line);
+			});
+
+			if (!file_exists(realpath($modSettings['sphinx_bin_path'] . '/indexer')))
+				return;
+		} catch (\Throwable $e) {
 			return;
+		} finally {
+			restore_error_handler();
+		}
 
 		$binary = realpath($modSettings['manticore_bin_path'] . '/indexer');
 

--- a/SMF 2.1/SearchAPI-Sphinxql.php
+++ b/SMF 2.1/SearchAPI-Sphinxql.php
@@ -5,12 +5,12 @@
  *
  * @package SMF
  * @author Simple Machines https://www.simplemachines.org
- * @copyright 2021 Simple Machines and individual contributors
+ * @copyright 2023 Simple Machines and individual contributors
  * @license https://www.simplemachines.org/about/smf/license.php BSD
  *
  * The Following fixes a bug in SMF to show this in the settings section.
  * SearchAPI-Sphinxql.php
- * @version 2.1 RC4
+ * @version 2.1.3
  */
 
 if (!defined('SMF'))
@@ -372,7 +372,7 @@ class sphinxql_search extends search_api
 			$cleanWords = $this->_cleanString($token[2]);
 
 			// Explode the cleanWords again incase the cleaning put more spaces into it
-			$addWords = $phrase ? array('"' . $cleanWords . '"') : preg_split('~ ~u', $cleanWords, NULL, PREG_SPLIT_NO_EMPTY);
+			$addWords = $phrase ? array('"' . $cleanWords . '"') : preg_split('~ ~u', $cleanWords, -1, PREG_SPLIT_NO_EMPTY);
 
 			if ($token[1] == '-')
 				$keywords['exclude'] = array_merge($keywords['exclude'], $addWords);

--- a/SMF 2.1/SearchAPI-Sphinxql.php
+++ b/SMF 2.1/SearchAPI-Sphinxql.php
@@ -338,6 +338,12 @@ class sphinxql_search extends search_api
 		foreach ($searchWords as $orIndex => $words)
 			$searchArray = array_merge($searchArray, $searchWords[$orIndex]['subject_words']);
 
+		// Work around SMF bug causing multiple pages to not work right.
+		if (!isset($_SESSION['search_cache']['num_results']))
+			$_SESSION['search_cache'] = [
+				'num_results' => $cached_results['total']
+			];
+
 		return $cached_results['total'];
 	}
 

--- a/SMF 2.1/SearchAPI-Sphinxql.php
+++ b/SMF 2.1/SearchAPI-Sphinxql.php
@@ -857,8 +857,19 @@ class sphinxql_search extends search_api
 		if (empty($modSettings['sphinx_bin_path']))
 			$modSettings['sphinx_bin_path'] = '/usr/bin';
 
-		if (!file_exists(realpath($modSettings['sphinx_bin_path'] . '/indexer')))
+		// Try to safely check for the indexer file, but do this in a way we can catch the error so PHP doesn't output it.
+		try {
+			set_error_handler(static function ($severity, $message, $file, $line) {
+				throw new \ErrorException($message, 0, $severity, $file, $line);
+			});
+
+			if (!file_exists(realpath($modSettings['sphinx_bin_path'] . '/indexer')))
+				return;
+		} catch (\Throwable $e) {
 			return;
+		} finally {
+			restore_error_handler();
+		}
 
 		$binary = realpath($modSettings['sphinx_bin_path'] . '/indexer');
 

--- a/package-info.xml
+++ b/package-info.xml
@@ -2,7 +2,7 @@
 <package-info xmlns="http://www.simplemachines.org/xml/package-info" xmlns:smf="http://www.simplemachines.org/">
 	<id>simplemachines:Sphinx-for-SMF</id>
 	<name>Sphinx for SMF</name>
-	<version>1.2</version>
+	<version>1.3</version>
 	<type>modification</type>
 
 	<install for="SMF 2.0-2.0.99">


### PR DESCRIPTION
Fixes #27 
Fixes #26

Safely catch indexer errors because of open base dir restrictions.
Sometimes we can't reach the binary, so allow us to specify the version manually
Fix Deprecated PHP features
Also update versions/copyright years