### PR TITLE
fix empty results when result set is too large to cache

### DIFF
--- a/SMF 2.0/SearchAPI-Sphinxql.php
+++ b/SMF 2.0/SearchAPI-Sphinxql.php
@@ -236,7 +236,8 @@ class sphinxql_search
 		global $user_info, $context, $modSettings;
 
 		// Only request the results if they haven't been cached yet.
-		if (($cached_results = cache_get_data('search_results_' . md5($user_info['query_see_board'] . '_' . $context['params']))) === null)
+		$cached_results = cache_get_data('search_results_' . md5($user_info['query_see_board'] . '_' . $context['params']));		
+		if (!is_array($cached_results))
 		{
 			// Create an instance of the sphinx client.
 			$mySphinx = $this->dbfunc_connect();

--- a/SMF 2.1/SearchAPI-Manticore.php
+++ b/SMF 2.1/SearchAPI-Manticore.php
@@ -240,7 +240,8 @@ class manticore_search extends search_api
 		global $user_info, $context, $modSettings;
 
 		// Only request the results if they haven't been cached yet.
-		if (($cached_results = cache_get_data('Xsearch_results_' . md5($user_info['query_see_board'] . '_' . $context['params']))) === null)
+		$cached_results = cache_get_data('Xsearch_results_' . md5($user_info['query_see_board'] . '_' . $context['params']));
+		if (!is_array($cached_results))
 		{
 			// Create an instance of the manticore client.
 			$myManticore = $this->dbfunc_connect();

--- a/SMF 2.1/SearchAPI-Sphinxql.php
+++ b/SMF 2.1/SearchAPI-Sphinxql.php
@@ -250,7 +250,8 @@ class sphinxql_search extends search_api
 		global $user_info, $context, $modSettings;
 
 		// Only request the results if they haven't been cached yet.
-		if (($cached_results = cache_get_data('Xsearch_results_' . md5($user_info['query_see_board'] . '_' . $context['params']))) === null)
+		$cached_results = cache_get_data('Xsearch_results_' . md5($user_info['query_see_board'] . '_' . $context['params']));
+		if (!is_array($cached_results))
 		{
 			// Create an instance of the sphinx client.
 			$mySphinx = $this->dbfunc_connect();


### PR DESCRIPTION
`cache_get_data` may return `false` when the cached data was too large for the configured cache backend to store the value. This results in the sesarch results becoming empty when users refresh or move to the next page.

This fixes this by checking if the result of `cache_get_data` is an array before attempting to use it.